### PR TITLE
feat: make set method unavailable on router instance

### DIFF
--- a/clean-stores/index.d.ts
+++ b/clean-stores/index.d.ts
@@ -1,5 +1,5 @@
 import { MapBuilder, AnySyncBuilder } from '../define-map/index.js'
-import { Store } from '../create-store/index.js'
+import { StoreLike } from '../create-store/index.js'
 
 export const clean: unique symbol
 
@@ -18,5 +18,5 @@ export const clean: unique symbol
  * @return Promise for stores destroying.
  */
 export function cleanStores(
-  ...stores: (Store | MapBuilder | AnySyncBuilder)[]
+  ...stores: (StoreLike | MapBuilder | AnySyncBuilder)[]
 ): void

--- a/create-router/errors.ts
+++ b/create-router/errors.ts
@@ -36,3 +36,6 @@ router.subscribe(page => {
 openPage(router, 'post', { id: '1', category: 'guides' })
 // THROWS Expected 2 arguments, but got 3
 openPage(router, 'home', { id: '1' })
+
+// THROWS Property 'set' does not exist on type
+router.set({ route: 'home', params: {}, path: '/' })

--- a/create-router/index.d.ts
+++ b/create-router/index.d.ts
@@ -52,8 +52,9 @@ export type Page<
  * })
  * ```
  */
-export type Router<AppPages extends Pages = Pages> = Store<
-  Page<AppPages, keyof AppPages> | undefined
+export type Router<AppPages extends Pages = Pages> = Omit<
+  Store<Page<AppPages, keyof AppPages> | undefined>,
+  'set'
 > & {
   /**
    * Converted routes.

--- a/create-router/index.js
+++ b/create-router/index.js
@@ -70,12 +70,12 @@ export function createRouter(routes) {
 
   let popstate = () => {
     let page = parse(location.pathname)
-    if (page !== false) router.set(page)
+    if (page !== false) setState(page)
   }
 
   let router = createStore(() => {
     let page = parse(location.pathname)
-    if (page !== false) router.set(page)
+    if (page !== false) setState(page)
     document.body.addEventListener('click', click)
     window.addEventListener('popstate', popstate)
     return () => {
@@ -85,13 +85,15 @@ export function createRouter(routes) {
     }
   })
 
+  let setState = router.set
+  delete router.set
   router.routes = normalized
 
   router.open = path => {
     let page = parse(path)
     if (page !== false) {
       history.pushState(null, null, path)
-      router.set(page)
+      setState(page)
     }
   }
 

--- a/create-router/index.test.ts
+++ b/create-router/index.test.ts
@@ -163,7 +163,7 @@ it('accepts click on tag inside link', () => {
 
   let link = createTag(document.body, 'a', { href: '/posts' })
   createTag(link, 'span').click()
-  expect(getValue(router)?.path).toEqual('/posts')
+  expect(getValue(router).path).toEqual('/posts')
 })
 
 it('ignore non-link clicks', () => {
@@ -171,7 +171,7 @@ it('ignore non-link clicks', () => {
   listen()
 
   createTag(document.body, 'span', { href: '/posts' }).click()
-  expect(getValue(router)?.path).toEqual('/')
+  expect(getValue(router).path).toEqual('/')
 })
 
 it('ignores special clicks', () => {
@@ -182,7 +182,7 @@ it('ignores special clicks', () => {
   let event = new MouseEvent('click', { bubbles: true, ctrlKey: true })
   link.dispatchEvent(event)
 
-  expect(getValue(router)?.path).toEqual('/')
+  expect(getValue(router).path).toEqual('/')
 })
 
 it('ignores other mouse button click', () => {
@@ -193,7 +193,7 @@ it('ignores other mouse button click', () => {
   let event = new MouseEvent('click', { bubbles: true, button: 2 })
   link.dispatchEvent(event)
 
-  expect(getValue(router)?.path).toEqual('/')
+  expect(getValue(router).path).toEqual('/')
 })
 
 it('ignores prevented events', () => {
@@ -207,7 +207,7 @@ it('ignores prevented events', () => {
   })
   span.click()
 
-  expect(getValue(router)?.path).toEqual('/')
+  expect(getValue(router).path).toEqual('/')
 })
 
 it('ignores links with noRouter data attribute', () => {
@@ -219,7 +219,7 @@ it('ignores links with noRouter data attribute', () => {
   let span = createTag(link, 'span')
   span.click()
 
-  expect(getValue(router)?.path).toEqual('/')
+  expect(getValue(router).path).toEqual('/')
 })
 
 it('ignores new-tab links', () => {
@@ -229,7 +229,7 @@ it('ignores new-tab links', () => {
   let link = createTag(document.body, 'a', { href: '/posts', target: '_blank' })
   link.click()
 
-  expect(getValue(router)?.path).toEqual('/')
+  expect(getValue(router).path).toEqual('/')
 })
 
 it('ignores external links', () => {
@@ -239,7 +239,7 @@ it('ignores external links', () => {
   let link = createTag(document.body, 'a', { href: 'http://lacalhast/posts' })
   link.click()
 
-  expect(getValue(router)?.path).toEqual('/')
+  expect(getValue(router).path).toEqual('/')
   expect(events).toHaveLength(0)
 })
 
@@ -261,7 +261,7 @@ it('respects data-ignore-router', () => {
   link.setAttribute('data-no-router', '1')
   link.click()
 
-  expect(getValue(router)?.path).toEqual('/')
+  expect(getValue(router).path).toEqual('/')
 })
 
 it('respects external rel', () => {
@@ -274,7 +274,7 @@ it('respects external rel', () => {
   })
   link.click()
 
-  expect(getValue(router)?.path).toEqual('/')
+  expect(getValue(router).path).toEqual('/')
 })
 
 it('respects download attribute', () => {
@@ -287,7 +287,7 @@ it('respects download attribute', () => {
   })
   link.click()
 
-  expect(getValue(router)?.path).toEqual('/')
+  expect(getValue(router).path).toEqual('/')
 })
 
 it('opens URLs manually', () => {

--- a/create-store/index.d.ts
+++ b/create-store/index.d.ts
@@ -1,6 +1,11 @@
 type ReadonlyIfObject<Value> = Value extends object ? Readonly<Value> : Value
 
-export type StoreValue<SomeStore> = SomeStore extends Store<infer Value>
+export type StoreLike<Value> = Pick<
+  Store<Value>,
+  'subscribe' | 'active' | 'value'
+>
+
+export type StoreValue<SomeStore> = SomeStore extends StoreLike<infer Value>
   ? Value
   : any
 

--- a/get-value/index.d.ts
+++ b/get-value/index.d.ts
@@ -1,4 +1,4 @@
-import { Store } from '../create-store/index.js'
+import { StoreLike, StoreValue } from '../create-store/index.js'
 
 /**
  * Shortcut to subscribe for store, get value and unsubscribe immediately.
@@ -14,6 +14,6 @@ import { Store } from '../create-store/index.js'
  * @param store The store.
  * @returns Store value.
  */
-export function getValue<Value extends any>(
-  store: Store<Value>
-): Readonly<Value>
+export function getValue<Value extends any, TStore extends StoreLike<Value>>(
+  store: TStore
+): Readonly<StoreValue<TStore>>

--- a/keep-active/index.d.ts
+++ b/keep-active/index.d.ts
@@ -1,5 +1,5 @@
 import { MapBuilder, AnySyncBuilder } from '../define-map/index.js'
-import { Store } from '../create-store/index.js'
+import { StoreLike } from '../create-store/index.js'
 
 /**
  * Add empty listener to the store to active store and prevent loosing store’s
@@ -15,4 +15,4 @@ import { Store } from '../create-store/index.js'
  *
  * @param store The store.
  */
-export function keepActive(store: Store | MapBuilder | AnySyncBuilder): void
+export function keepActive(store: StoreLike | MapBuilder | AnySyncBuilder): void

--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
       "import": {
         "./index.js": "{ createRouter }"
       },
-      "limit": "753 B"
+      "limit": "764 B"
     }
   ],
   "yaspeller": {

--- a/preact/index.d.ts
+++ b/preact/index.d.ts
@@ -1,4 +1,4 @@
-import { Store } from '../create-store/index.js'
+import { StoreLike, StoreValue } from '../create-store/index.js'
 
 /**
  * Subscribe to store changes and get store’s value.
@@ -22,4 +22,6 @@ import { Store } from '../create-store/index.js'
  * @param store Store instance.
  * @returns Store value.
  */
-export function useStore<Value extends any>(store: Store<Value>): Value
+export function useStore<Value extends any, TStore extends StoreLike<Value>>(
+  store: TStore
+): StoreValue<TStore>

--- a/react/index.d.ts
+++ b/react/index.d.ts
@@ -1,4 +1,4 @@
-import { Store } from '../create-store/index.js'
+import { StoreLike, StoreValue } from '../create-store/index.js'
 
 /**
  * Subscribe to store changes and get store’s value.
@@ -22,4 +22,6 @@ import { Store } from '../create-store/index.js'
  * @param store Store instance.
  * @returns Store value.
  */
-export function useStore<Value extends any>(store: Store<Value>): Value
+export function useStore<Value extends any, TStore extends StoreLike<Value>>(
+  store: TStore
+): StoreValue<TStore>

--- a/vue/index.d.ts
+++ b/vue/index.d.ts
@@ -1,6 +1,6 @@
 import { DeepReadonly, Ref } from 'vue'
 
-import { Store } from '../create-store/index.js'
+import { StoreLike, StoreValue } from '../create-store/index.js'
 
 type ReadonlyRef<Type> = DeepReadonly<Ref<Type>>
 
@@ -28,6 +28,6 @@ type ReadonlyRef<Type> = DeepReadonly<Ref<Type>>
  * @param store Store instance.
  * @returns Store value.
  */
-export function useStore<Value extends any>(
-  store: Store<Value>
-): ReadonlyRef<Value>
+export function useStore<Value extends any, TStore extends StoreLike<Value>>(
+  store: TStore
+): ReadonlyRef<StoreValue<TStore>>


### PR DESCRIPTION
Calling `set` method directly could cause state not in sync with actual location.
This includes both fix in types and in runtime.
Introduced new generic type `StoreLike` with minimal subset of properties most utility functions expect to work with.